### PR TITLE
[download] added  

### DIFF
--- a/includes/Shortcode.php
+++ b/includes/Shortcode.php
@@ -263,3 +263,4 @@ function downloadsOutput( $args ) {
 }
 
 add_shortcode('downloads', 'downloadsHandler');
+add_shortcode('download', 'downloadsHandler');


### PR DESCRIPTION
shortcode ought to be [downloads] since at least May 2015  but f.e. there are website that use [download] 